### PR TITLE
Capitalize Python

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -150,7 +150,7 @@ Astroquery identifies itself to host services using the \texttt{HTTP
 User-Agent} header data.  The format of the User-Agent string is
 \texttt{astroquery/\{version\} \{requests\_version\}}, where
 \texttt{\{version\}} is a version number of the form \#.\#.\# and
-\texttt{\{requests\_version\}} is the corresponding version of the python
+\texttt{\{requests\_version\}} is the corresponding version of the Python
 requests module.  This information can be used by data hosting services
 to determine how many users are accessing their service via astroquery
 and to assist in debugging if improper queries are being posted.
@@ -298,7 +298,7 @@ modules, which is a helpful practice we encourage.
 \end{itemize}
 
 \section{Summary}
-Astroquery is a toolkit for accessing remotely hosted data through python.
+Astroquery is a toolkit for accessing remotely hosted data through Python.
 It is part of the astropy affiliated package system.  
 We have described its general layout and development model.
 We welcome any new contributions.


### PR DESCRIPTION
Capitalize "python" to "Python".