### PR TITLE
Appendix A: Fix typo

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -398,7 +398,7 @@ In this appendix, we show an example of \astroquery in action, highlighting the
 ability to use multiple modules and interact with \astropypkg's table, coordinate,
 and unit tools.  This example approximately reproduces Figure 1 of
 \citet{Eisner2016a}, but with a different background.  It can also be found on
-\astropypkg's gallery page
+\astroquery's gallery page
 (\url{http://astroquery.readthedocs.io/en/latest/gallery.html}).
 Another illustration of how to use astroquery tools in a finder chart making 
 tool is \texttt{fcmaker}, which produces charts for ESO observations using


### PR DESCRIPTION
Link implies Astroquery gallery but text says Astropy gallery.